### PR TITLE
Add configuration to enabling LINBUS mode on USART for STM32 

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -207,7 +207,7 @@ pub struct Config {
     /// Set the pull configuration for the RX pin.
     pub rx_pull: Pull,
 
-    // Set this to true to enable sending LIN synchronous breaks
+    /// Set this to true to enable sending LIN synchronous breaks
     #[cfg(any(usart_v3, usart_v4))]
     pub lin_enable: bool,
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -207,6 +207,10 @@ pub struct Config {
     /// Set the pull configuration for the RX pin.
     pub rx_pull: Pull,
 
+    // Set this to true to enable sending LIN synchronous breaks
+    #[cfg(any(usart_v3, usart_v4))]
+    pub lin_enable: bool,
+
     // private: set by new_half_duplex, not by the user.
     duplex: Duplex,
 }
@@ -247,6 +251,8 @@ impl Default for Config {
             #[cfg(any(usart_v3, usart_v4))]
             invert_rx: false,
             rx_pull: Pull::None,
+            #[cfg(any(usart_v3, usart_v4))]
+            lin_enable: false,
             duplex: Duplex::Full,
         }
     }
@@ -1694,6 +1700,7 @@ fn configure(
             w.set_txinv(config.invert_tx);
             w.set_rxinv(config.invert_rx);
             w.set_swap(config.swap_rx_tx);
+            w.set_linen(config.lin_enable);
         }
     });
 


### PR DESCRIPTION
Add configuration to USART to set LINEN for usart_v3/v4 devices, to allowed USART to operate in LIN mode